### PR TITLE
Add support for previewing posts & pages

### DIFF
--- a/js/components/post/page.jsx
+++ b/js/components/post/page.jsx
@@ -14,6 +14,7 @@ import ContentMixin from 'utils/content-mixin';
 import Media from './image';
 import Comments from 'components/comments';
 import Placeholder from 'components/placeholder';
+import PostPreview from './preview';
 
 const SinglePage = React.createClass( {
 	mixins: [ ContentMixin ],
@@ -65,6 +66,12 @@ const SinglePage = React.createClass( {
 	},
 
 	render() {
+		if ( !! this.props.previewId ) {
+			return (
+				<PostPreview id={ this.props.previewId } />
+			);
+		}
+
 		return (
 			<div className="card">
 				<QueryPage pagePath={ this.props.path } />
@@ -90,7 +97,10 @@ export default connect( ( state, ownProps ) => {
 	const requesting = isRequestingPage( state, path );
 	const post = getPage( state, parseInt( postId ) );
 
+	const previewId = ownProps.location.query.preview_id;
+
 	return {
+		previewId,
 		path,
 		postId,
 		post,

--- a/js/components/post/preview.jsx
+++ b/js/components/post/preview.jsx
@@ -7,6 +7,7 @@ import BodyClass from 'react-body-class';
 
 // Internal dependencies
 import { getPost } from 'wordpress-query-posts/lib/selectors';
+import { getPage } from 'wordpress-query-page/lib/selectors';
 import ContentMixin from 'utils/content-mixin';
 
 // Components
@@ -45,7 +46,7 @@ const SinglePost = React.createClass( {
 				<div className="entry-meta"></div>
 				<div className="entry-content" dangerouslySetInnerHTML={ this.getContent( post ) } />
 
-				<PostMeta post={ post } humanDate={ this.getDate( post ) } />
+				{ 'post' === post.type && <PostMeta post={ post } humanDate={ this.getDate( post ) } /> }
 			</article>
 		);
 	},
@@ -61,7 +62,7 @@ const SinglePost = React.createClass( {
 
 export default connect( ( state, ownProps ) => {
 	const postId = parseInt( ownProps.id, 10 );
-	const post = getPost( state, postId );
+	const post = getPost( state, postId ) || getPage( state, postId );
 
 	return {
 		postId,

--- a/js/components/post/preview.jsx
+++ b/js/components/post/preview.jsx
@@ -6,16 +6,12 @@ import DocumentMeta from 'react-document-meta';
 import BodyClass from 'react-body-class';
 
 // Internal dependencies
-import QueryPosts from 'wordpress-query-posts';
-import { getPostIdFromSlug, isRequestingPost, getPost } from 'wordpress-query-posts/lib/selectors';
+import { getPost } from 'wordpress-query-posts/lib/selectors';
 import ContentMixin from 'utils/content-mixin';
 
 // Components
 import PostMeta from './meta';
 import Media from './image';
-import Comments from 'components/comments';
-import Placeholder from 'components/placeholder';
-import PostPreview from './preview';
 
 const SinglePost = React.createClass( {
 	mixins: [ ContentMixin ],
@@ -54,56 +50,21 @@ const SinglePost = React.createClass( {
 		);
 	},
 
-	renderComments() {
-		const post = this.props.post;
-		if ( ! post ) {
-			return null;
-		}
-
-		return (
-			<Comments
-				protected={ post.content.protected }
-				postId={ this.props.postId }
-				title={ <span dangerouslySetInnerHTML={ this.getTitle( post ) } /> }
-				commentsOpen={ 'open' === post.comment_status } />
-		)
-	},
-
 	render() {
-		if ( !! this.props.previewId ) {
-			return (
-				<PostPreview id={ this.props.previewId } />
-			);
-		}
-
 		return (
 			<div className="card">
-				<QueryPosts postSlug={ this.props.slug } />
-				{ this.props.loading ?
-					<Placeholder type="post" /> :
-					this.renderArticle()
-				}
-
-				{ ! this.props.loading && this.renderComments() }
+				{ this.renderArticle() }
 			</div>
 		);
 	}
 } );
 
 export default connect( ( state, ownProps ) => {
-	const slug = ownProps.params.slug || false;
-	const postId = getPostIdFromSlug( state, slug );
-	const requesting = isRequestingPost( state, slug );
-	const post = getPost( state, parseInt( postId ) );
-
-	const previewId = ownProps.location.query.preview_id;
+	const postId = parseInt( ownProps.id, 10 );
+	const post = getPost( state, postId );
 
 	return {
-		previewId,
-		slug,
 		postId,
-		post,
-		requesting,
-		loading: requesting && ! post
+		post
 	};
 } )( SinglePost );

--- a/js/components/posts/index.jsx
+++ b/js/components/posts/index.jsx
@@ -60,7 +60,7 @@ export default connect( ( state, ownProps ) => {
 
 	const posts = getPostsForQuery( state, query ) || [];
 	const requesting = isRequestingPostsForQuery( state, query );
-	const previewId = ownProps.location.query.p;
+	const previewId = ownProps.location.query.p || ownProps.location.query.page_id;
 
 	return {
 		previewId,

--- a/js/components/posts/index.jsx
+++ b/js/components/posts/index.jsx
@@ -11,11 +11,18 @@ import { isRequestingPostsForQuery, getPostsForQuery, getTotalPagesForQuery } fr
 
 // Components
 import PostList from './list';
+import PostPreview from '../post/preview';
 import Pagination from 'components/pagination/archive';
 import Placeholder from 'components/placeholder';
 
 const Index = React.createClass( {
 	render() {
+		if ( !! this.props.previewId ) {
+			return (
+				<PostPreview id={ this.props.previewId } />
+			);
+		}
+
 		const posts = this.props.posts;
 		const meta = {
 			title: FoxhoundSettings.meta.title,
@@ -53,8 +60,10 @@ export default connect( ( state, ownProps ) => {
 
 	const posts = getPostsForQuery( state, query ) || [];
 	const requesting = isRequestingPostsForQuery( state, query );
+	const previewId = ownProps.location.query.p;
 
 	return {
+		previewId,
 		path,
 		page: parseInt( query.page ),
 		query,

--- a/js/components/posts/index.jsx
+++ b/js/components/posts/index.jsx
@@ -11,7 +11,7 @@ import { isRequestingPostsForQuery, getPostsForQuery, getTotalPagesForQuery } fr
 
 // Components
 import PostList from './list';
-import PostPreview from '../post/preview';
+import PostPreview from 'components/post/preview';
 import Pagination from 'components/pagination/archive';
 import Placeholder from 'components/placeholder';
 


### PR DESCRIPTION
This adds support for previewing both new posts and pages (drafts), and editing published posts and pages.

I'm being a little clever, by not using the API to fetch this data, and instead relying on the preloaded data in the page to be the correct data I want. And it is, since you're only getting to these pages by clicking from wp-admin, the initial page load will be for the preview data, and the global `$post` data in `get_post_data` contains the updated or draft data. 🎉