### PR TITLE
Add a component for sticky posts

### DIFF
--- a/js/components/author/list.jsx
+++ b/js/components/author/list.jsx
@@ -1,7 +1,7 @@
 /*global FoxhoundSettings */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import isEqual from 'lodash/isequal';
+import isEqual from 'lodash/isEqual';
 
 // Internal dependencies
 import QueryPosts from 'wordpress-query-posts';

--- a/js/components/posts/index.jsx
+++ b/js/components/posts/index.jsx
@@ -11,6 +11,7 @@ import { isRequestingPostsForQuery, getPostsForQuery, getTotalPagesForQuery } fr
 
 // Components
 import PostList from './list';
+import StickyPostsList from './sticky';
 import PostPreview from 'components/post/preview';
 import Pagination from 'components/pagination/archive';
 import Placeholder from 'components/placeholder';
@@ -34,6 +35,7 @@ const Index = React.createClass( {
 			<div className="site-content">
 				<DocumentMeta { ...meta } />
 				<BodyClass classes={ [ 'home', 'blog' ] } />
+				<StickyPostsList />
 				<QueryPosts query={ this.props.query } />
 				{ this.props.loading ?
 					<Placeholder type="posts" /> :
@@ -51,6 +53,7 @@ const Index = React.createClass( {
 
 export default connect( ( state, ownProps ) => {
 	let query = {};
+	query.sticky = false;
 	query.page = ownProps.params.paged || 1;
 
 	let path = FoxhoundSettings.URL.path || '/';

--- a/js/components/posts/sticky.jsx
+++ b/js/components/posts/sticky.jsx
@@ -1,0 +1,45 @@
+// External dependencies
+import React from 'react';
+import { connect } from 'react-redux';
+import isEqual from 'lodash/isequal';
+
+// Redux dependencies
+import QueryPosts from 'wordpress-query-posts';
+import { isRequestingPostsForQuery, getPostsForQuery } from 'wordpress-query-posts/lib/selectors';
+
+// Components
+import PostList from './list';
+
+const StickyPostsList = React.createClass( {
+	shouldComponentUpdate( nextProps ) {
+		return ! isEqual( nextProps.posts, this.props.posts );
+	},
+
+	render() {
+		const posts = this.props.posts;
+
+		return (
+			<div className="sticky-container">
+				<QueryPosts query={ this.props.query } />
+				<PostList posts={ posts } />
+			</div>
+		);
+	}
+} );
+
+export default connect( ( state ) => {
+	const query = {};
+	query.page = 1;
+	query.per_page = 2;
+	query.sticky = true;
+
+	const posts = getPostsForQuery( state, query ) || [];
+	const requesting = isRequestingPostsForQuery( state, query );
+
+	return {
+		query,
+		posts,
+		requesting,
+		loading: requesting && ! posts,
+	};
+} )( StickyPostsList );

--- a/js/components/posts/sticky.jsx
+++ b/js/components/posts/sticky.jsx
@@ -1,7 +1,7 @@
 // External dependencies
 import React from 'react';
 import { connect } from 'react-redux';
-import isEqual from 'lodash/isequal';
+import isEqual from 'lodash/isEqual';
 
 // Redux dependencies
 import QueryPosts from 'wordpress-query-posts';

--- a/js/components/posts/test/fixtures/store.js
+++ b/js/components/posts/test/fixtures/store.js
@@ -27,13 +27,13 @@ export const data = {
 			}
 		},
 		totalPages: {
-			'{"page":1}': '2',
+			'{"sticky":false,"page":1}': '2',
 		},
 		queryRequests: {
-			'{"page":1}': false,
+			'{"sticky":false,"page":1}': false,
 		},
 		queries: {
-			'{"page":1}': [ 1, 2 ],
+			'{"sticky":false,"page":1}': [ 1, 2 ],
 		}
 	}
 }

--- a/js/components/term/list.jsx
+++ b/js/components/term/list.jsx
@@ -1,7 +1,7 @@
 /*global FoxhoundSettings */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import isEqual from 'lodash/isequal';
+import isEqual from 'lodash/isEqual';
 
 // Internal dependencies
 import QueryPosts from 'wordpress-query-posts';

--- a/js/utils/initial-actions.js
+++ b/js/utils/initial-actions.js
@@ -47,7 +47,7 @@ export function setPosts( posts, totalPages ) {
 
 		dispatch( {
 			type: POSTS_REQUEST_SUCCESS,
-			query: { page: 1 },
+			query: { page: 1, sticky: false },
 			totalPages,
 			posts
 		} );


### PR DESCRIPTION
Fixes #47 

Adds a component with a second query request for up to two sticky posts, which display on the homepage (and all subsequent paged pages). This also removes sticky posts from the main posts list.