### PR TITLE
Convert from HTML entities in the site title

### DIFF
--- a/js/components/attachment/index.jsx
+++ b/js/components/attachment/index.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import DocumentMeta from 'react-document-meta';
 import BodyClass from 'react-body-class';
+import he from 'he';
 
 // Internal dependencies
 import Placeholder from 'components/placeholder';
@@ -26,6 +27,7 @@ const Attachment = React.createClass( {
 			description: media.caption.rendered,
 			canonical: media.link,
 		};
+		meta.title = he.decode( meta.title );
 
 		return (
 			<article className={ classNames( [ 'entry' ] ) }>

--- a/js/components/author/index.jsx
+++ b/js/components/author/index.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import DocumentMeta from 'react-document-meta';
 import BodyClass from 'react-body-class';
+import he from 'he';
 
 // Internal dependencies
 import QueryUser from 'wordpress-query-user';
@@ -14,6 +15,7 @@ const AuthorHeader = ( { userName, loading, user = {}, query = {} } ) => {
 	const meta = {
 		title: user.name + ' – ' + FoxhoundSettings.meta.title,
 	};
+	meta.title = he.decode( meta.title );
 
 	return (
 		<div className="card">

--- a/js/components/date/index.jsx
+++ b/js/components/date/index.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import DocumentMeta from 'react-document-meta';
 import BodyClass from 'react-body-class';
 import moment from 'moment';
+import he from 'he';
 
 // Internal dependencies
 import QueryPosts from 'wordpress-query-posts';
@@ -18,7 +19,7 @@ const DateArchive = React.createClass( {
 	render() {
 		const { query, loading, path, page, totalPages, dateString, posts } = this.props;
 		const meta = {
-			title: dateString + ' – ' + FoxhoundSettings.meta.title,
+			title: dateString + ' – ' + he.decode( FoxhoundSettings.meta.title ),
 		};
 
 		return (

--- a/js/components/not-found/index.jsx
+++ b/js/components/not-found/index.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import classNames from 'classnames';
 import DocumentMeta from 'react-document-meta';
 import BodyClass from 'react-body-class';
+import he from 'he';
 
 const NotFound = React.createClass( {
 	render() {
@@ -12,7 +13,7 @@ const NotFound = React.createClass( {
 		} );
 
 		const meta = {
-			title: 'Page not found – ' + FoxhoundSettings.meta.title,
+			title: 'Page not found – ' + he.decode( FoxhoundSettings.meta.title ),
 		};
 
 		return (

--- a/js/components/post/index.jsx
+++ b/js/components/post/index.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import DocumentMeta from 'react-document-meta';
 import BodyClass from 'react-body-class';
+import he from 'he';
 
 // Internal dependencies
 import QueryPosts from 'wordpress-query-posts';
@@ -31,6 +32,7 @@ const SinglePost = React.createClass( {
 			description: post.excerpt.rendered,
 			canonical: post.link,
 		};
+		meta.title = he.decode( meta.title );
 
 		const classes = classNames( {
 			entry: true

--- a/js/components/post/page.jsx
+++ b/js/components/post/page.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import DocumentMeta from 'react-document-meta';
 import BodyClass from 'react-body-class';
+import he from 'he';
 
 // Internal dependencies
 import QueryPage from 'wordpress-query-page';
@@ -30,6 +31,7 @@ const SinglePage = React.createClass( {
 			description: post.excerpt.rendered,
 			canonical: post.link,
 		};
+		meta.title = he.decode( meta.title );
 
 		const classes = classNames( {
 			entry: true

--- a/js/components/post/preview.jsx
+++ b/js/components/post/preview.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import DocumentMeta from 'react-document-meta';
 import BodyClass from 'react-body-class';
+import he from 'he';
 
 // Internal dependencies
 import { getPost } from 'wordpress-query-posts/lib/selectors';
@@ -28,6 +29,7 @@ const SinglePost = React.createClass( {
 			description: post.excerpt.rendered,
 			canonical: post.link,
 		};
+		meta.title = he.decode( meta.title );
 
 		const classes = classNames( {
 			entry: true

--- a/js/components/posts/index.jsx
+++ b/js/components/posts/index.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import DocumentMeta from 'react-document-meta';
 import BodyClass from 'react-body-class';
+import he from 'he';
 
 // Internal dependencies
 import QueryPosts from 'wordpress-query-posts';
@@ -26,7 +27,7 @@ const Index = React.createClass( {
 
 		const posts = this.props.posts;
 		const meta = {
-			title: FoxhoundSettings.meta.title,
+			title: he.decode( FoxhoundSettings.meta.title ),
 			description: FoxhoundSettings.meta.description,
 			canonical: FoxhoundSettings.URL.base,
 		};

--- a/js/components/search/index.jsx
+++ b/js/components/search/index.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import DocumentMeta from 'react-document-meta';
 import BodyClass from 'react-body-class';
+import he from 'he';
 
 // Internal dependencies
 import QueryPosts from 'wordpress-query-posts';
@@ -34,6 +35,7 @@ const Search = React.createClass( {
 		const meta = {
 			title: 'Search Results for "' + term + '" – ' + FoxhoundSettings.meta.title,
 		};
+		meta.title = he.decode( meta.title );
 
 		return (
 			<div className='site-content'>

--- a/js/components/term/index.jsx
+++ b/js/components/term/index.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import DocumentMeta from 'react-document-meta';
 import BodyClass from 'react-body-class';
+import he from 'he';
 
 // Internal dependencies
 import QueryTerm from 'wordpress-query-term';
@@ -15,6 +16,7 @@ const TermHeader = ( { term, taxonomy, loading, termData = {}, query = {} } ) =>
 		title: termData.name + ' – ' + FoxhoundSettings.meta.title,
 		description: termData.description,
 	};
+	meta.title = he.decode( meta.title );
 
 	return (
 		<div className="card">

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "glob": "^7.1.1",
+    "he": "^1.1.1",
     "lodash": "^4.17.2",
     "moment": "^2.16.0",
     "react": "^15.4.0",


### PR DESCRIPTION
Use `he` to decode the site meta title before setting it in DocumentMeta, preventing things like this report:

> Foxhound keeps stripping ' from site title in browser tab and replacing it with #039;. Any ideas? Tried to remove wptexturizer thx!

https://twitter.com/PennomArt/status/846837895436623872