### PR TITLE
fixes broken single views when avatars are disabled

### DIFF
--- a/js/components/comments/single.jsx
+++ b/js/components/comments/single.jsx
@@ -26,9 +26,11 @@ function Comment( props ) {
 		<li className={ classes }>
 			<article className="comment-body">
 				<footer className="comment-meta">
-					<div className="comment-avatar vcard">
-						<img alt="" src={ comment.author_avatar_urls[ '96' ] } />
-					</div>
+					{ comment.author_avatar_urls ? (
+						<div className="comment-avatar vcard">
+							<img alt="" src={ comment.author_avatar_urls[ '96' ] } />
+						</div>
+					) : '' }
 
 					<div className="comment-author">
 						{ '' !== comment.author_url ? (


### PR DESCRIPTION
Howdy 😃👋 Proposing this to only show comment avatar if set. Users can disable avatar display under Settings > Discussion, which presently breaks single page views with comments (by screaming that comment.author_avatar_urls is undefined).